### PR TITLE
fix: package.json getting postended with "null"

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -154,7 +154,7 @@ async function detect_newline_at_eof(path) {
 		return matches[0];
 	}
 
-	return null;
+	return '';
 }
 
 function sleep(ms) {


### PR DESCRIPTION
I'm having an issue where my package.json ends with `null` after running the script. This should fix this issue for users whose package.json has no EOL character.

- since the result of this function gets added to a string, if it's null, my package.json ends up with a "null" at the end.
- by returning an empty string nothing will be added as an EOL character